### PR TITLE
Use Workload Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ This repository contains a Ruby script that consumes the various service/vender 
 The environment variables below are required:
 
 ```
-FIRESTORE_CREDENTIALS       # Path to the GCP service account JSON key
 FIRESTORE_PROJECT           # Name of the GCP project containing the Firestore project
 SLACK_WEBHOOK               # Used for accessing the Slack Incoming Webhooks API
 STATUS_ALERTS_SLACK_CHANNEL # Name of the Slack channel to post alerts to
+```
+
+The environment variables below are optional:
+
+```
+FIRESTORE_CREDENTIALS       # Path to the GCP service account JSON key (used when running locally)
 ```
 
 Run the script using `bundle exec ./cloud_status_alerter.rb`.
@@ -36,4 +41,4 @@ Updates from a status feed source are implemented by providers, which are simply
 | uri       | URI for viewing this individual status update online                                   |
 
 ## Copyright
-Copyright (C) 2019 Crown Copyright (Office for National Statistics)
+Copyright (C) 2019&ndash;2020 Crown Copyright (Office for National Statistics)

--- a/cloud_status_alerter.rb
+++ b/cloud_status_alerter.rb
@@ -69,11 +69,10 @@ class CloudStatusAlerter
     firestore_project     = ENV['FIRESTORE_PROJECT']
     firestore_credentials = ENV['FIRESTORE_CREDENTIALS']
     raise 'Missing FIRESTORE_PROJECT environment variable' unless firestore_project
-    raise 'Missing FIRESTORE_CREDENTIALS environment variable' unless firestore_credentials
-
+    
     Google::Cloud::Firestore.configure do |config|
       config.project_id  = firestore_project
-      config.credentials = firestore_credentials
+      config.credentials = firestore_credentials if firestore_credentials
     end
 
     @firestore_client = Google::Cloud::Firestore.new


### PR DESCRIPTION
Made `FIRESTORE_CREDENTIALS` optional as it's not required when running on a GKE cluster with Workload Identity enabled.