### PR TITLE
Slack change from webhook to token

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The environment variables below are required:
 
 ```
 FIRESTORE_PROJECT           # Name of the GCP project containing the Firestore project
-SLACK_WEBHOOK               # Used for accessing the Slack Incoming Webhooks API
+SLACK_BOT_TOKEN             # Used for accessing the Slack API
 STATUS_ALERTS_SLACK_CHANNEL # Name of the Slack channel to post alerts to
 ```
 

--- a/cloud_status_alerter.rb
+++ b/cloud_status_alerter.rb
@@ -87,10 +87,10 @@ class CloudStatusAlerter
       'text': text,
       'attachments': []
     }.to_json.encode('UTF-8')
-    headers = { 'Content-Type': 'application/json' }
+    headers = { 'Content-Type': 'application/json', 'Authorization': ENV['SLACK_BOT_TOKEN'].chomp }
     begin
       sleep THREE_SECONDS # Avoid Slack's rate limits.
-      RestClient.post(ENV['SLACK_WEBHOOK'].chomp, payload, headers)
+      RestClient.post('https://slack.com/api/chat.postMessage', payload, headers)
       @logger.info text
     rescue RestClient::ExceptionWithResponse => e
       @logger.error("Error posting to Slack: HTTP #{e.response.code} #{e.response}")


### PR DESCRIPTION
Tested with:

```
require 'json'

require 'rest-client'

class Test
    def post_slack_message
        text = 'Hello Jo and Da'
        url = 'https://slack.com/api/chat.postMessage'
        payload = {
          'channel': "CLZ1Y8YAU",
          'icon_emoji': ":jim:",
          'username': "jimbot - Cloud Status Bot",
          'text': text,
          'attachments': []
        }.to_json.encode('UTF-8')
        headers = { 'Content-Type': 'application/json', 'Authorization': 'XXXX' }
        begin
          print(url)
          print(payload)
          print(headers)
          print(RestClient.post(url, payload, headers))
        rescue RestClient::ExceptionWithResponse => e
          print("Error posting to Slack: HTTP #{e.response.code} #{e.response}")
        end
    end
end

Test.new.post_slack_message`
```